### PR TITLE
Remove leading space from keywords.txt identifier token

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,15 +1,15 @@
 ## TinyGA - keywords.txt
 
 # Classes (KEYWORD1):
-TinyGA	  KEYWORKD1
+TinyGA	KEYWORKD1
 
 # Methods and Functions (KEYWORD2):
-init	  KEYWORD2
-load	  KEYWORD2
-save	  KEYWORD2
-print	  KEYWORD2
-reset	  KEYWORD2
-run	  KEYWORD2
+init	KEYWORD2
+load	KEYWORD2
+save	KEYWORD2
+print	KEYWORD2
+reset	KEYWORD2
+run	KEYWORD2
 
 # Constants (LITERAL1):
 MAX_POPULATION	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3, LITERAL2).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords